### PR TITLE
Secure parameter support

### DIFF
--- a/exporters/export_managers/base_exporter.py
+++ b/exporters/export_managers/base_exporter.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import datetime
 import traceback
 from exporters.export_managers.bypass import RequisitesNotMet
@@ -10,29 +11,69 @@ from exporters.writers.base_writer import ItemsLimitReached
 
 
 class BaseExporter(object):
-
     def __init__(self, configuration):
+        self.configuration = configuration
         self.config = ExporterConfig(configuration)
         self.logger = ExportManagerLogger(self.config.log_options)
         self.module_loader = ModuleLoader()
         self.reader = self.module_loader.load_reader(self.config.reader_options)
-        self.filter_before = self.module_loader.load_filter(self.config.filter_before_options)
-        self.filter_after = self.module_loader.load_filter(self.config.filter_after_options)
+        self.filter_before = self.module_loader.load_filter(
+            self.config.filter_before_options)
+        self.filter_after = self.module_loader.load_filter(
+            self.config.filter_after_options)
         self.transform = self.module_loader.load_transform(self.config.transform_options)
         self.writer = self.module_loader.load_writer(self.config.writer_options)
-        self.persistence = self.module_loader.load_persistence(self.config.persistence_options)
-        self.export_formatter = self.module_loader.load_formatter(self.config.formatter_options)
+        self.persistence = self.module_loader.load_persistence(
+            self.config.persistence_options)
+        self.export_formatter = self.module_loader.load_formatter(
+            self.config.formatter_options)
         self.grouper = self.module_loader.load_grouper(self.config.grouper_options)
         self.notifiers = NotifiersList(self.config.notifiers)
         self.logger.debug('{} has been initiated'.format(self.__class__.__name__))
+        self.stats_manager = self.module_loader.load_stats_manager(
+            self.config.stats_options)
         job_info = {
-            'configuration': configuration,
+            'configuration': self.secure_configuration,
             'items_count': 0,
             'start_time': datetime.datetime.now(),
             'script_name': 'basic_export_manager'
         }
-        self.stats_manager = self.module_loader.load_stats_manager(self.config.stats_options)
         self.stats_manager.stats = job_info
+
+    def _secure_regular_modules(self):
+        secure_config = deepcopy(self.configuration)
+        supported_options = {'reader': self.reader.supported_options,
+                             'writer': self.writer.supported_options,
+                             'persistence': self.persistence.supported_options,
+                             'stats_manager': self.stats_manager.supported_options,
+                             'filter_before': self.filter_before.supported_options,
+                             'filter_after': self.filter_after.supported_options,
+                             'transform': self.transform.supported_options,
+                             'grouper': self.grouper.supported_options,
+                             'export_formatter': self.export_formatter.supported_options
+                             }
+        for module, s_options in supported_options.iteritems():
+            for key, supported_option in s_options.iteritems():
+                if 'secret' in supported_option:
+                    secure_config[module]['options'].pop(key)
+        return secure_config
+
+    def _secure_notifiers(self):
+        secure_config = deepcopy(
+            self.configuration.get('exporter_options', {}).get('notifications', []))
+        notifiers = {notifier.__module__ + '.' + notifier.__class__.__name__:
+                         notifier.supported_options for notifier in self.notifiers.notifiers}
+        for i, n in enumerate(secure_config):
+            for key, supported_option in notifiers[n['name']].iteritems():
+                if 'secret' in supported_option:
+                    secure_config[i]['options'].pop(key)
+        return secure_config
+
+    @property
+    def secure_configuration(self):
+        secure_config = self._secure_regular_modules()
+        secure_config['exporter_options']['notifications'] = self._secure_notifiers()
+        return secure_config
 
     def _run_pipeline_iteration(self):
         self.logger.debug('Getting new batch')
@@ -47,7 +88,8 @@ class BaseExporter(object):
         self.persistence.commit_position(last_position)
 
     def _init_export_job(self):
-        self.notifiers.notify_start_dump(receivers=[CLIENTS, TEAM], info=self.stats_manager.stats)
+        self.notifiers.notify_start_dump(receivers=[CLIENTS, TEAM],
+                                         info=self.stats_manager.stats)
         last_position = self.persistence.get_last_position()
         self.reader.set_last_position(last_position)
 
@@ -58,7 +100,8 @@ class BaseExporter(object):
     def _finish_export_job(self):
         self.stats_manager.stats['items_count'] = self.writer.items_count
         self.stats_manager.stats['end_time'] = datetime.datetime.now()
-        self.stats_manager.stats['elapsed_time'] = self.stats_manager.stats['end_time'] - self.stats_manager.stats['start_time']
+        self.stats_manager.stats['elapsed_time'] = self.stats_manager.stats['end_time'] - \
+                                                   self.stats_manager.stats['start_time']
 
     @property
     def bypass_cases(self):
@@ -66,10 +109,13 @@ class BaseExporter(object):
 
     def bypass_exporter(self, bypass_script):
         self.logger.info('Executing bypass {}.'.format(bypass_script.__class__.__name__))
-        self.notifiers.notify_start_dump(receivers=[CLIENTS, TEAM], info=self.stats_manager.stats)
+        self.notifiers.notify_start_dump(receivers=[CLIENTS, TEAM],
+                                         info=self.stats_manager.stats)
         bypass_script.bypass()
-        self.logger.info('Finished executing bypass {}.'.format(bypass_script.__class__.__name__))
-        self.notifiers.notify_complete_dump(receivers=[CLIENTS, TEAM], info=self.stats_manager.stats)
+        self.logger.info(
+            'Finished executing bypass {}.'.format(bypass_script.__class__.__name__))
+        self.notifiers.notify_complete_dump(receivers=[CLIENTS, TEAM],
+                                            info=self.stats_manager.stats)
 
     def bypass(self):
         for bypass_script in self.bypass_cases:
@@ -78,13 +124,16 @@ class BaseExporter(object):
                 self.bypass_exporter(bypass_script)
                 return True
             except RequisitesNotMet:
-                self.logger.debug('{} bypass skipped.'.format(bypass_script.__class__.__name__))
+                self.logger.debug(
+                    '{} bypass skipped.'.format(bypass_script.__class__.__name__))
         return False
 
     def _handle_export_exception(self, exception):
         self.logger.error(traceback.format_exc(exception))
         self.logger.error(str(exception))
-        self.notifiers.notify_failed_job(str(exception), str(traceback.format_exc(exception)), receivers=[TEAM], info=self.stats_manager.stats)
+        self.notifiers.notify_failed_job(str(exception),
+                                         str(traceback.format_exc(exception)),
+                                         receivers=[TEAM], info=self.stats_manager.stats)
 
     def _run_pipeline(self):
         while not self.reader.is_finished():
@@ -101,7 +150,8 @@ class BaseExporter(object):
             try:
                 self._init_export_job()
                 self._run_pipeline()
-                self.notifiers.notify_complete_dump(receivers=[CLIENTS, TEAM], info=self.stats_manager.stats)
+                self.notifiers.notify_complete_dump(receivers=[CLIENTS, TEAM],
+                                                    info=self.stats_manager.stats)
             except Exception as e:
                 self._handle_export_exception(e)
                 raise e

--- a/exporters/notifications/s3_mail_notifier.py
+++ b/exporters/notifications/s3_mail_notifier.py
@@ -27,8 +27,8 @@ class S3MailNotifier(BaseNotifier):
         self.supported_options = {
             'team_mails': {'type': list, 'default': []},
             'client_mails': {'type': list, 'default': []},
-            'aws_login': {'type': basestring},
-            'aws_key': {'type': basestring}
+            'aws_login': {'type': basestring, 'secret': True},
+            'aws_key': {'type': basestring, 'secret': True}
         }
 
         super(S3MailNotifier, self).__init__(options)

--- a/exporters/readers/hubstorage_reader.py
+++ b/exporters/readers/hubstorage_reader.py
@@ -32,7 +32,7 @@ class HubstorageReader(BaseReader):
     # List of options to set up the reader
     supported_options = {
         'batch_size': {'type': int, 'default': 10000},
-        'apikey': {'type': basestring},
+        'apikey': {'type': basestring, 'secret': True},
         'project_id': {'type': basestring},
         'collection_name': {'type': basestring},
         'count': {'type': int, 'default': 0},

--- a/exporters/readers/s3_reader.py
+++ b/exporters/readers/s3_reader.py
@@ -34,8 +34,8 @@ class S3Reader(BaseReader):
     supported_options = {
         'batch_size': {'type': int, 'default': 10000},
         'bucket': {'type': basestring},
-        'aws_access_key_id': {'type': basestring},
-        'aws_secret_access_key': {'type': basestring},
+        'aws_access_key_id': {'type': basestring, 'secret': True},
+        'aws_secret_access_key': {'type': basestring, 'secret': True},
         'tmp_folder': {'type': basestring, 'default': '/tmp/'},
         'prefix': {'type': basestring}
     }

--- a/exporters/writers/ftp_writer.py
+++ b/exporters/writers/ftp_writer.py
@@ -32,8 +32,8 @@ class FTPWriter(FilebaseBaseWriter):
     supported_options = {
         'host': {'type': basestring},
         'port': {'type': int},
-        'ftp_user': {'type': basestring},
-        'ftp_password': {'type': basestring}
+        'ftp_user': {'type': basestring, 'secret': True},
+        'ftp_password': {'type': basestring, 'secret': True}
     }
 
     def __init__(self, options):

--- a/exporters/writers/mail_writer.py
+++ b/exporters/writers/mail_writer.py
@@ -33,8 +33,8 @@ class MailWriter(BaseWriter):
         'subject': {'type': basestring},
         'from': {'type': basestring},
         'max_mails_sent': {'type': int, 'default': 5},
-        'aws_login': {'type': basestring},
-        'aws_key': {'type': basestring}
+        'aws_login': {'type': basestring, 'secret': True},
+        'aws_key': {'type': basestring, 'secret': True}
     }
 
     def __init__(self, options):

--- a/exporters/writers/s3_writer.py
+++ b/exporters/writers/s3_writer.py
@@ -27,8 +27,8 @@ class S3Writer(FilebaseBaseWriter):
     """
     supported_options = {
         'bucket': {'type': basestring},
-        'aws_access_key_id': {'type': basestring},
-        'aws_secret_access_key': {'type': basestring},
+        'aws_access_key_id': {'type': basestring, 'secret': True},
+        'aws_secret_access_key': {'type': basestring, 'secret': True},
         'aws_region': {'type': basestring, 'default': 'us-east-1'},
     }
 

--- a/exporters/writers/sftp_writer.py
+++ b/exporters/writers/sftp_writer.py
@@ -28,8 +28,8 @@ class SFTPWriter(FilebaseBaseWriter):
     supported_options = {
         'host': {'type': basestring},
         'port': {'type': int},
-        'sftp_user': {'type': basestring},
-        'sftp_password': {'type': basestring}
+        'sftp_user': {'type': basestring, 'secret': True},
+        'sftp_password': {'type': basestring, 'secret': True}
     }
 
     def __init__(self, options):

--- a/tests/test_export_manager.py
+++ b/tests/test_export_manager.py
@@ -48,7 +48,7 @@ class BaseExportManagerTest(unittest.TestCase):
 
                 }
             },
-            'writer':{
+            'writer': {
                 'name': 'exporters.writers.console_writer.ConsoleWriter',
                 'options': {
 
@@ -78,7 +78,6 @@ class BaseExportManagerTest(unittest.TestCase):
 
 
 class BasicExportManagerTest(unittest.TestCase):
-
     def setUp(self):
         self.options = {
             'exporter_options': {
@@ -91,7 +90,23 @@ class BasicExportManagerTest(unittest.TestCase):
                         'columns': ['city', 'country_code'],
                         'titles': ['City', 'CC']
                     }
-                }
+                },
+                "notifications": [
+                    {
+                        "name": "exporters.notifications.s3_mail_notifier.S3MailNotifier",
+                        "options": {
+                            "client_name": "someclient",
+                            "team_mails": [
+                                "teammail@mail"
+                            ],
+                            "client_mails": [
+                                "clientmail@mail"
+                            ],
+                            "aws_login": "somekey",
+                            "aws_key": "someotherkey"
+                        }
+                    }
+                ]
             },
             'reader': {
                 'name': 'exporters.readers.random_reader.RandomReader',
@@ -118,7 +133,7 @@ class BasicExportManagerTest(unittest.TestCase):
 
                 }
             },
-            'writer':{
+            'writer': {
                 'name': 'exporters.writers.console_writer.ConsoleWriter',
                 'options': {
 
@@ -142,6 +157,12 @@ class BasicExportManagerTest(unittest.TestCase):
         self.assertTrue(isinstance(self.exporter.transform, NoTransform))
 
     def test_from_file_configuration(self):
-        test_manager = BasicExporter.from_file_configuration('./tests/data/basic_config.json')
+        test_manager = BasicExporter.from_file_configuration(
+            './tests/data/basic_config.json')
         self.assertIsInstance(test_manager, BasicExporter)
         test_manager._clean_export_job()
+
+    def test_secure_option(self):
+        options = self.exporter.secure_configuration['exporter_options']['notifications'][0]['options']
+        self.assertNotIn('aws_login', options)
+        self.assertNotIn('aws_key', options)


### PR DESCRIPTION
Allows the possibility to add metadata to set module parameters as secret. Then, that parameters won't show on logs of notifications.
