### PR TITLE
remove uninformative logs

### DIFF
--- a/exporters/filters/no_filter.py
+++ b/exporters/filters/no_filter.py
@@ -8,7 +8,6 @@ class NoFilter(BaseFilter):
 
     def __init__(self, options):
         super(NoFilter, self).__init__(options)
-        self.logger.info('NoFilter has been initiated')
 
     def filter_batch(self, batch):
         return batch

--- a/exporters/transform/no_transform.py
+++ b/exporters/transform/no_transform.py
@@ -3,13 +3,12 @@ from exporters.transform.base_transform import BaseTransform
 
 class NoTransform(BaseTransform):
     """
-    It leaves the batch as is. This is provided for the cases where no transformations are needed on the original items.
+    It leaves the batch as is.
+    This is provided for the cases where no transformations are needed on the original items.
     """
 
     def __init__(self, options):
         super(NoTransform, self).__init__(options)
-        self.logger.info('NoTransform has been initiated')
 
     def transform_batch(self, batch):
-        self.logger.debug('Transformed items')
         return batch


### PR DESCRIPTION
The no-ops aren't doing anything useful (specially since they're default now), we don't need to have them in the logs.
