### PR TITLE
Fix issue when jq transform has a filter, cleanup tests

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,7 +1,6 @@
 import unittest
 from exporters.records.base_record import BaseRecord
 from exporters.transform.base_transform import BaseTransform
-from exporters.transform.jq_transform import JQTransform
 from exporters.transform.no_transform import NoTransform
 from exporters.transform.pythonexp_transform import PythonexpTransform
 from exporters.module_loader import ModuleLoader
@@ -56,36 +55,6 @@ class NoTransformTest(unittest.TestCase):
         # FIXME inline batch, without a reader
         batch = reader.get_next_batch()
         self.assertTrue(self.transform.transform_batch(batch) == batch)
-
-
-class JqTransformTest(unittest.TestCase):
-    def setUp(self):
-        self.options = {
-            'exporter_options': {
-                'log_level': 'DEBUG',
-                'logger_name': 'export-pipeline'
-            },
-        }
-
-        self.batch = [BaseRecord({'name': 'item1', 'country_code': 'es'}), BaseRecord({'name': 'item2', 'country_code': 'uk'})]
-
-
-    def test_transform_empty_batch(self):
-        transform = JQTransform({'options': {'jq_filter': '.'}})
-        self.assertTrue(list(transform.transform_batch([])) == [])
-
-    def test_no_transform_batch(self):
-        transform = JQTransform({'options': {'jq_filter': '.'}})
-        index = 0
-        for item in list(transform.transform_batch(self.batch)):
-            self.assertEqual(item, self.batch[index])
-            index += 1
-
-    def test_transform_batch(self):
-        transform = JQTransform({'options': {'jq_filter': '{country_code: .country_code}'}})
-        for item in list(transform.transform_batch(self.batch)):
-            self.assertIn('country_code', item)
-            self.assertNotIn('name', item)
 
 
 class PythonexpTransformTest(unittest.TestCase):

--- a/tests/test_transforms_jq.py
+++ b/tests/test_transforms_jq.py
@@ -1,0 +1,38 @@
+import unittest
+from exporters.records.base_record import BaseRecord
+from exporters.transform.jq_transform import JQTransform
+
+
+class JqTransformTest(unittest.TestCase):
+    def setUp(self):
+        self.options = {
+            'exporter_options': {
+                'log_level': 'DEBUG',
+                'logger_name': 'export-pipeline'
+            },
+        }
+
+        self.batch = [
+            BaseRecord({'name': 'item1', 'country_code': 'es'}),
+            BaseRecord({'name': 'item2', 'country_code': 'uk'}),
+        ]
+
+    def test_transform_empty_batch(self):
+        transform = JQTransform({'options': {'jq_filter': '.'}})
+        self.assertEquals([], list(transform.transform_batch([])))
+
+    def test_no_transform_batch(self):
+        transform = JQTransform({'options': {'jq_filter': '.'}})
+        self.assertEqual(self.batch, list(transform.transform_batch(self.batch)))
+
+    def test_transform_batch(self):
+        transform = JQTransform({'options': {'jq_filter': '{country: .country_code}'}})
+        expected = [{'country': 'es'}, {'country': 'uk'}]
+        self.assertEqual(expected, list(transform.transform_batch(self.batch)))
+
+    def test_transform_with_filter(self):
+        for country in ['es', 'uk']:
+            jq_filter = 'select(.country_code == "%s") | {country_code}' % country
+            transform = JQTransform({'options': {'jq_filter': jq_filter}})
+            expected = [{'country_code': country}]
+            self.assertEqual(expected, list(transform.transform_batch(self.batch)))


### PR DESCRIPTION
Hey @bbotella:

I found this issue while debugging the issue that @tsrdatatech had today: `jq.transform()` raises StopIteration when the item should be filtered, that was making our outer for loop to stop silently. :)

Anyway, I decided to make the JQ transform a filter too.
I thought about removing the JQ filter and leaving only the transform, but I think we can leave it too, as users looking for filter would find it more easily.

Merging this now, but please feel free to comment any issue you see on it and we can follow up later!
Gracias!
