### PR TITLE
Made exporter_options optional

### DIFF
--- a/exporters/exporter_config.py
+++ b/exporters/exporter_config.py
@@ -12,7 +12,7 @@ class ExporterConfig(object):
     def __init__(self, configuration):
         check_for_errors(configuration)
         self.configuration = configuration
-        self.exporter_options = self.configuration['exporter_options']
+        self.exporter_options = self.configuration.get('exporter_options', {})
         self.reader_options = self._merge_options('reader')
         if 'filter' in self.configuration:
             self.filter_before_options = self._merge_options('filter')
@@ -63,8 +63,7 @@ def module_options():
     return options
 
 
-REQUIRED_CONFIG_SECTIONS = frozenset(
-    ['reader', 'writer', 'exporter_options'])
+REQUIRED_CONFIG_SECTIONS = frozenset(['reader', 'writer'])
 
 
 Parameter = collections.namedtuple('Parameter', 'name options')


### PR DESCRIPTION
That what have resulted in start with invalid config - exporter_options just wasn't checked.
You wanted to make it optional, so here you could have it :)
