### PR TITLE
Fix issue of incorrect success notification, add writer.flush to end of pipeline

### DIFF
--- a/exporters/export_managers/base_exporter.py
+++ b/exporters/export_managers/base_exporter.py
@@ -118,6 +118,7 @@ class BaseExporter(object):
             else:
                 self._update_stats()
                 self._populate_stats()
+        self.writer.flush()
 
     def export(self):
         if not self.bypass():

--- a/exporters/writers/base_writer.py
+++ b/exporters/writers/base_writer.py
@@ -71,15 +71,15 @@ class BaseWriter(BasePipelineItem):
             raise ItemsLimitReached('Finishing job after items_limit reached:'
                                     ' {} items written.'.format(self.items_count))
 
+    def flush(self):
+        for key in self.grouping_info.keys():
+            self._write(key)
+
     def close(self):
         """
         Called to clean all possible tmp files created during the process.
         """
-        try:
-            for key in self.grouping_info.keys():
-                self._write(key)
-        finally:
-            self.write_buffer.close()
+        self.write_buffer.close()
         self._check_write_consistency()
 
     @property

--- a/tests/test_export_manager.py
+++ b/tests/test_export_manager.py
@@ -1,4 +1,5 @@
 import os
+import mock
 import unittest
 from exporters.export_managers.base_exporter import BaseExporter
 from exporters.export_managers.basic_exporter import BasicExporter
@@ -7,88 +8,81 @@ from exporters.exporter_config import ExporterConfig
 from exporters.readers.random_reader import RandomReader
 from exporters.transform.no_transform import NoTransform
 from exporters.writers.console_writer import ConsoleWriter
+from .utils import valid_config_with_updates
 
 
 def get_filename(path, persistence_id):
     return os.path.join(path, persistence_id)
 
+
+def fail(*a, **kw):
+    raise ValueError("fail")
+
+
 class BaseExportManagerTest(unittest.TestCase):
-    def setUp(self):
-        self.config = {
-            'exporter_options': {
-                'log_level': 'DEBUG',
-                'logger_name': 'export-pipeline',
-                'formatter': {
-                    'name': 'exporters.export_formatter.csv_export_formatter.CSVExportFormatter',
-                    'options': {
-                        'show_titles': True,
-                        'fields': ['city', 'country_code']
-                    }
-                }
-            },
+    def build_config(self, **kwargs):
+        defaults = {
             'reader': {
                 'name': 'exporters.readers.random_reader.RandomReader',
                 'options': {
                     'number_of_items': 10,
                     'batch_size': 1
                 }
-            },
-            'filter': {
-                'name': 'exporters.filters.no_filter.NoFilter',
-                'options': {
-
-                }
-            },
-            'filter_after': {
-                'name': 'exporters.filters.no_filter.NoFilter',
-                'options': {
-
-                }
-            },
-            'transform': {
-                'name': 'exporters.transform.no_transform.NoTransform',
-                'options': {
-
-                }
-            },
-            'writer':{
-                'name': 'exporters.writers.console_writer.ConsoleWriter',
-                'options': {
-
-                }
-            },
-            'persistence': {
-                'name': 'exporters.persistence.pickle_persistence.PicklePersistence',
-                'options': {
-                    'file_path': '/tmp/'
-                }
             }
         }
+        defaults.update(**kwargs)
+        return valid_config_with_updates(defaults)
 
-    def test_iteration(self):
-        try:
-            exporter = BaseExporter(self.config)
-            self.assertIs(exporter._run_pipeline_iteration(), None)
-            exporter._clean_export_job()
-        finally:
-            exporter.persistence.delete()
+    def tearDown(self):
+        if hasattr(self, 'exporter'):
+            self.exporter.persistence.delete()
 
-    def test_full_export(self):
-        try:
-            exporter = BaseExporter(self.config)
-            self.assertIs(exporter._handle_export_exception(Exception()), None)
-            self.assertIs(exporter.export(), None)
-        finally:
-            exporter.persistence.delete()
+    def test_simple_export(self):
+        self.exporter = exporter = BaseExporter(self.build_config())
+        exporter.export()
+        self.assertEquals(10, exporter.writer.items_count)
+
+    def test_export_with_csv_formatter(self):
+        config = self.build_config()
+        config['exporter_options']['formatter'] = {
+            'name': 'exporters.export_formatter.csv_export_formatter.CSVExportFormatter',
+            'options': {
+                'show_titles': True,
+                'fields': ['city', 'country_code']
+            }
+        }
+        self.exporter = exporter = BaseExporter(config)
+        exporter.export()
+        expected_count = 10 + 1  # FIXME: it's currently counting header as an item
+        self.assertEquals(expected_count, exporter.writer.items_count)
 
     def test_bypass(self):
-        try:
-            exporter = BaseExporter(self.config)
-            with self.assertRaises(NotImplementedError):
-                exporter.bypass_exporter(BaseBypass(ExporterConfig(self.config)))
-            exporter._clean_export_job()
-        finally:
-            exporter.persistence.delete()
+        self.exporter = exporter = BaseExporter(self.build_config())
+        with self.assertRaises(NotImplementedError):
+            exporter.bypass_exporter(BaseBypass(ExporterConfig(self.build_config())))
+        exporter._clean_export_job()
+
+    @mock.patch('exporters.writers.ftp_writer.FTPWriter.write', new=fail)
+    @mock.patch('exporters.export_managers.base_exporter.NotifiersList')
+    def test_when_writing_only_on_flush_should_notify_job_failure(self, mock_notifier):
+        config = self.build_config(
+            writer={
+                'name': 'exporters.writers.FTPWriter',
+                'options': {
+                    'host': 'ftp.invalid.com',
+                    'filebase': '_',
+                    'ftp_user': 'invaliduser',
+                    'ftp_password': 'invalidpass',
+                }
+            },
+        )
+        self.exporter = exporter = BaseExporter(config)
+        with self.assertRaisesRegexp(ValueError, "fail"):
+            exporter.export()
+        self.assertFalse(mock_notifier.return_value.notify_complete_dump.called,
+                         "Should not notify a successful dump")
+        self.assertTrue(mock_notifier.return_value.notify_failed_job.called,
+                        "Should notify the job failure")
 
 
 class BasicExportManagerTest(unittest.TestCase):
@@ -113,7 +107,7 @@ class BasicExportManagerTest(unittest.TestCase):
                     'batch_size': 100
                 }
             },
-            'writer':{
+            'writer': {
                 'name': 'exporters.writers.console_writer.ConsoleWriter',
                 'options': {
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -61,6 +61,7 @@ class CustomWriterTest(unittest.TestCase):
         # when:
         try:
             writer.write_batch(self.batch)
+            writer.flush()
         finally:
             writer.close()
 
@@ -96,6 +97,7 @@ class CustomWriterTest(unittest.TestCase):
         # when:
         try:
             writer.write_batch(self.batch)
+            writer.flush()
         finally:
             writer.close()
 
@@ -118,6 +120,7 @@ class CustomWriterTest(unittest.TestCase):
         # when:
         try:
             writer.write_batch(self.batch)
+            writer.flush()
         finally:
             writer.close()
         self.assertEqual(writer.items_count, 3)

--- a/tests/test_writers_s3.py
+++ b/tests/test_writers_s3.py
@@ -47,9 +47,12 @@ class S3WriterTest(unittest.TestCase):
         options = self.get_writer_config()
 
         # when:
-        writer = S3Writer(options)
-        writer.write_batch(items_to_write)
-        writer.close()
+        try:
+            writer = S3Writer(options)
+            writer.write_batch(items_to_write)
+            writer.flush()
+        finally:
+            writer.close()
 
         # then:
         bucket = self.s3_conn.get_bucket('fake_bucket')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
-import os
+from copy import deepcopy
+
 
 VALID_EXPORTER_CONFIG = {
     'reader': {
@@ -25,12 +26,12 @@ VALID_EXPORTER_CONFIG = {
         'options': {'file_base': '/tmp'}
     },
     'grouper': {
-        'name': 'exporters.grouper.no_grouper.NoGrouper',
+        'name': 'exporters.groupers.no_grouper.NoGrouper',
     }
 }
 
 
 def valid_config_with_updates(updates):
-    config = VALID_EXPORTER_CONFIG.copy()
+    config = deepcopy(VALID_EXPORTER_CONFIG)
     config.update(updates)
     return config


### PR DESCRIPTION
So, the problem is that for small deliveries (when item count does not reach the buffer limit), the writer is actually writing only when [its `.close()` method](https://github.com/scrapinghub/exporters/blob/887f2aa8b0e3044e6b1e8725c81e66735a9af150/exporters/writers/base_writer.py#L79) is called.

This causes the weird behavior of the delivery being notified as complete before the writer has even written any data yet, because [`writer.close()` is called on BaseExporter._clean_export_job](https://github.com/scrapinghub/exporters/blob/887f2aa8b0e3044e6b1e8725c81e66735a9af150/exporters/export_managers/base_exporter.py#L137) which is after the success notification.

I fixed the problem by moving the flushing logic that was in method `BaseWriter.close()` to a `BaseWriter.flush()` method, keeping the `close()` for cleanup semantics only, and calling `writer.flush()` at the end of the pipeline.

I also took the opportunity to improve the export manager tests, and added a test verifying this particular behavior of incorrect success notification.
