### PR TITLE
Exclude tests from exporters package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 setup(
     name         = 'exporters',
     version      = '0.1',
-    packages     = find_packages(),
+    packages     = find_packages(exclude=['tests']),
     test_suite   = 'tests',
     tests_require = ['mock', 'moto', 'coverage'],
 )


### PR DESCRIPTION
I bumped into a weird problem in another package because exporter' tests were conflicting with the package tests.

`tests` should really not be a part of the package.
