### PR TITLE
It gets all the fields in schema, and not only the required ones.

### DIFF
--- a/exporters/export_formatter/csv_export_formatter.py
+++ b/exporters/export_formatter/csv_export_formatter.py
@@ -24,7 +24,7 @@ class CSVExportFormatter(BaseExportFormatter):
 
     def _get_fields_from_schema(self):
         schema = self.read_option('schema')
-        return schema.get('properties', {}).keys()
+        return sorted(schema.get('properties', {}).keys())
 
     def _get_fields(self):
         if self.read_option('fields'):

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -118,14 +118,9 @@ class CSVFormatterTest(unittest.TestCase):
         # when:
         items = list(formatter.format(self.batch))
 
-        # print [i.formatted for i in items]
-        #
         # then:
         self.assertEqual([True] + [False] * 5, [i.header for i in items])
-        expected_titles = set(['"key1"','"key2"'])
-        given_titles = set(items[0].formatted.split(','))
-        items.pop(0)
-        self.assertEqual(expected_titles, given_titles)
-        for i in range(5):
-            self.assertEqual(set(['"value1"', '"value2"']), set(items[i].formatted.split(',')))
+        self.assertEqual(['"key1","key2"'] + ['"value1","value2"'] * 5,
+                         [i.formatted for i in items])
         self.assertEqual(set(['csv']), set(i.format for i in items))
+


### PR DESCRIPTION
This fixes a bug in CSV export formatter using schema. It only was exporting fields that were required, and not all of the possible fields.

@eliasdorneles, @tsrdatatech tells me that this is linked with a schema conversation you had yesterday.
