### PR TITLE
Improve missing option message

### DIFF
--- a/exporters/exporter_config.py
+++ b/exporters/exporter_config.py
@@ -128,7 +128,7 @@ def _get_option_error(name, spec, config_options):
     required = 'default' not in spec and 'env_fallback' not in spec
 
     if required and name not in config_options:
-        return 'Option is missing'
+        return 'Option %s is missing' % name
     else:
         value = config_options.get(name, empty)
         if value is not empty and not isinstance(value, spec['type']):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -193,7 +193,7 @@ class ConfigValidationTest(unittest.TestCase):
 
         exception = cm.exception
         expected_errors = {
-            'transform': {'jq_filter': 'Option is missing'}
+            'transform': {'jq_filter': 'Option jq_filter is missing'}
             }
         self.assertEqual(expected_errors, exception.errors)
 


### PR DESCRIPTION
Because `Option is missing` is a rather cryptic error message. :)

In fact, perhaps it would be nice even to say which section is missing the option:

```
Option %s is missing for %s module
```

for "Option jq_filter is missing for filter module"
