### PR TITLE
Adds json as a default format for base records.

### DIFF
--- a/exporters/records/base_record.py
+++ b/exporters/records/base_record.py
@@ -12,13 +12,17 @@ class BaseRecord(dict):
     """
     group_key = []
     group_membership = ()
-    formatted = ''
     format = 'json'
     header = False
 
     def __init__(self, *args, **kwargs):
         super(BaseRecord, self).__init__(*args, **kwargs)
-        self.formatted = self._default_format()
+        self._formatted = None
 
-    def _default_format(self):
-        return json.dumps(self)
+    @property
+    def formatted(self):
+        return json.dumps(self) if self._formatted is None else self._formatted
+
+    @formatted.setter
+    def formatted(self, fmt):
+        self._formatted = fmt


### PR DESCRIPTION
We hit a weird behaviour when using writers standalone. Items are written as empty lines to buffer files (as they don't go through a pipeline formatter). With this, we are adding a json.dumps as a default behaviour for base_record.formatted.
