### PR TITLE
support for lists of values in key_value_filter

### DIFF
--- a/exporters/filters/key_value_filter.py
+++ b/exporters/filters/key_value_filter.py
@@ -5,10 +5,22 @@ class KeyValueFilter(BaseFilter):
     """
     Filter items depending on keys and values
 
-        - keys (list)
-            It is a list of dicts with the following structure: {"key": "value"}.
-            The filter will delete those items that do not contain a
-            key "key" or, if they do, that key is not the same as "value".
+    Parameters
+    ----------
+    keys : list
+        It is a list of dicts with the following structure: {"key": "value"}.
+        "value can be either a value itself or an iterable (i.e., list, tuple))
+        The filter will delete those items that:
+        do not contain a key "key" or
+        their value either is not same as "value" (if value is not iterable) or
+        their value is not in "value" (if value is an iterable).
+
+    Examples
+    --------
+    >>> keys = [{'name': 'age', 'value': 25}, {'name': 'country', 'value': ['ES', 'PT']}]
+    >>> items = [{'age': 25, 'country': 'ES'}, {'age': 18, 'country': 'US'}, {'country': 'PT'}]
+    >>> list(filter(KeyValueFilter.filter, items))
+    {'age': 25, 'country': 'ES'}]
     """
     # List of options
     supported_options = {
@@ -24,8 +36,8 @@ class KeyValueFilter(BaseFilter):
         for kv in self.keys:
             if kv['name'] not in item:
                 return False
-            elif isinstance(kv['value'], list) and not(item[kv['name']] in kv['value']):
+            elif hasattr(kv["value"], '__iter__') and not(item[kv['name']] in kv['value']):
                 return False
-            elif not(isinstance(kv['value'], list)) and item[kv['name']] != kv['value']:
+            elif not(hasattr(kv["value"], '__iter__')) and item[kv['name']] != kv['value']:
                 return False
         return True

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -67,10 +67,14 @@ class KeyValueFilterTest(unittest.TestCase):
             }
         }
         self.keys = [
-            {'name': 'country_code', 'value': 'es'}
-            ]
-
-        items = [{'name': 'item1', 'country_code': 'es'}, {'name': 'item2', 'country_code': 'uk'}]
+                {'name': 'age', 'value': 25},
+                {'name': 'country_code', 'value': ['es', 'pt']}
+                ]
+        items = [
+                {'age': 25, 'country_code': 'es'},
+                {'age': 18, 'country_code': 'us'},
+                {'country_code': 'pt'}
+                ]
         self.batch = []
         for item in items:
             record = BaseRecord(item)


### PR DESCRIPTION
This change allows for the key value filter to match against a list of values instead of just one value.

For example:

``` python
keys = [{'name': 'age', 'value': 25}, {'name': 'country', 'value': ['ES', 'PT']}]
items = [{'age': 25, 'country': 'ES'}, {'age': 18, 'country': 'US'}, {'country': 'PT'}]
list(filter(key_value_filter.filter, items))
[Out:]
  [{'age': 25, 'country': 'ES'}]
```
