### PR TITLE
Using short retry for downloading pointers

### DIFF
--- a/exporters/readers/s3_reader.py
+++ b/exporters/readers/s3_reader.py
@@ -7,7 +7,7 @@ import datetime
 from exporters.progress_callback import BotoDownloadProgress
 from exporters.readers.base_reader import BaseReader
 from exporters.records.base_record import BaseRecord
-from exporters.default_retries import retry_long
+from exporters.default_retries import retry_long, retry_short
 from exporters.exceptions import ConfigurationError
 import logging
 
@@ -43,7 +43,7 @@ class S3BucketKeysFetcher(object):
         self.logger = logging.getLogger('s3-reader')
         self.logger.setLevel(logging.INFO)
 
-    @retry_long
+    @retry_short
     def _download_pointer(self, prefix_pointer):
         return self.source_bucket.get_key(prefix_pointer).get_contents_as_string()
 


### PR DESCRIPTION
We had an issue of [a job appearing to be stalled](https://staging.scrapinghub.com/p/28865/job/1/1550/#/log/line/0) (logged nothing more than 2 lines for 15 minutes), and the problem was simply that it was trying to download a prefix_pointer that didn't exist.

I think it's better to fail fast in this case (download pointer prefix), since we expect these files to be small -- hence this PR.
