### PR TITLE
Adds bucket owner full control to uploaded keys

### DIFF
--- a/exporters/export_managers/s3_to_s3_bypass.py
+++ b/exporters/export_managers/s3_to_s3_bypass.py
@@ -183,6 +183,7 @@ class S3Bypass(BaseBypass):
             dest_key = dest_bucket.new_key(dest_key_name)
             progress = BotoUploadProgress(self.logger)
             dest_key.set_contents_from_filename(tmp_filename, cb=progress)
+            dest_key.set_acl('bucket-owner-full-control')
 
     @retry_long
     def _copy_key(self, dest_bucket, dest_key_name, source_bucket, key_name):

--- a/exporters/writers/s3_writer.py
+++ b/exporters/writers/s3_writer.py
@@ -85,6 +85,7 @@ class S3Writer(FilebaseBaseWriter):
                 key.set_metadata('total', self._get_total_count(dump_path))
             progress = BotoDownloadProgress(self.logger)
             key.set_contents_from_file(f, cb=progress)
+            key.set_acl('bucket-owner-full-control')
         self.logger.info('Saved {}'.format(destination))
 
     def write(self, dump_path, group_key=None):


### PR DESCRIPTION
I think this one is a better solution for public repositories than leaving the keys public.
