### PR TITLE
Removed filebase formatting in constructor

### DIFF
--- a/exporters/writers/ftp_writer.py
+++ b/exporters/writers/ftp_writer.py
@@ -44,7 +44,6 @@ class FTPWriter(FilebaseBaseWriter):
         self.ftp_port = self.read_option('port')
         self.ftp_user = self.read_option('ftp_user')
         self.ftp_password = self.read_option('ftp_password')
-        self.filebase = self.read_option('filebase').format(datetime.datetime.now())
         self.logger.info(
             'FTPWriter has been initiated. host: {}. port: {}. filebase: {}'.format(
                 self.ftp_host, self.ftp_port,


### PR DESCRIPTION
It is done in `create_filebase_name` for months already
