### PR TITLE
Small fix: accept lines with carriage return in prefix pointer files

### DIFF
--- a/exporters/readers/s3_reader.py
+++ b/exporters/readers/s3_reader.py
@@ -56,7 +56,7 @@ class S3BucketKeysFetcher(object):
         return self.source_bucket.get_key(prefix_pointer).get_contents_as_string()
 
     def _fetch_prefixes_from_pointer(self, prefix_pointer):
-        return [pointer for pointer in self._download_pointer(prefix_pointer).split('\n') if pointer]
+        return filter(None, self._download_pointer(prefix_pointer).splitlines())
 
     def _get_keys_from_bucket(self):
         keys = []

--- a/tests/test_readers_s3.py
+++ b/tests/test_readers_s3.py
@@ -205,7 +205,7 @@ class TestS3BucketKeysFetcher(unittest.TestCase):
         bucket = self.s3_conn.get_bucket('last_bucket')
         key = bucket.new_key('test_list/LAST')
         self.pointers = ['pointer1', 'pointer2', 'pointer3', '']
-        key.set_contents_from_string('\n'.join(self.pointers))
+        key.set_contents_from_string('\r\n'.join(self.pointers))
         key.close()
 
         for key_name in POINTER_KEYS:


### PR DESCRIPTION
The metadata tracker split was failing for a manually written LAST file.

The fix is to use `str.splitlines` instead of `str.split('\n')`
