### PR TITLE
Fix filebase dates in writers

### DIFF
--- a/exporters/writers/filebase_base_writer.py
+++ b/exporters/writers/filebase_base_writer.py
@@ -53,7 +53,6 @@ class FilebaseBaseWriter(BaseWriter):
 
     def get_filebase_with_date(self):
         filebase = self.read_option('filebase')
-        filebase = filebase.format(date=datetime.datetime.now())
         filebase = datetime.datetime.now().strftime(filebase)
         return filebase
 


### PR DESCRIPTION
Generates date filebase info at writer init. And only gets groups info at every write.
