### PR TITLE
Minor cleanup on key value based filters

### DIFF
--- a/exporters/filters/key_value_filter.py
+++ b/exporters/filters/key_value_filter.py
@@ -1,14 +1,6 @@
-from exporters.filters.key_value_base_filter import KeyValueBaseFilter
+import warnings
+from .key_value_filters import KeyValueFilter  # NOQA
 
 
-class KeyValueFilter(KeyValueBaseFilter):
-    """
-    Filter items depending on keys and values
-
-        - keys (list)
-            It is a list of dicts with the following structure: {"key": "value"}.
-            The filter will delete those items that do not contain a
-            key "key" or, if they do, that key is not the same as "value".
-    """
-    def _match_value(self, found, expected):
-        return found == expected
+warnings.warn('Module exporters.filters.key_value_filter has been deprecated,'
+              ' use exporters.filters.key_values_filters instead')

--- a/exporters/filters/key_value_filters.py
+++ b/exporters/filters/key_value_filters.py
@@ -1,3 +1,5 @@
+import re
+
 from exporters.filters.base_filter import BaseFilter
 from exporters.utils import nested_dict_value
 
@@ -33,3 +35,29 @@ class KeyValueBaseFilter(BaseFilter):
         Should be overriden by derived classes implementing custom match.
         """
         raise NotImplementedError
+
+
+class KeyValueFilter(KeyValueBaseFilter):
+    """
+    Filter items depending on keys and values
+
+        - keys (list)
+            It is a list of dicts with the following structure: {"key": "value"}.
+            The filter will delete those items that do not contain a
+            key "key" or, if they do, that key is not the same as "value".
+    """
+    def _match_value(self, found, expected):
+        return found == expected
+
+
+class KeyValueRegexFilter(KeyValueBaseFilter):
+    """
+    Filter items depending on keys and values using regular expressions
+
+        - keys (list)
+            It is a list of dicts with the following structure: {"key": "regex"}.
+            The filter will delete those items that do not contain a
+            key "key" or, if they do, that key value does not match "regex".
+    """
+    def _match_value(self, found, expected):
+        return bool(re.match(expected, found))

--- a/exporters/filters/key_value_regex_filter.py
+++ b/exporters/filters/key_value_regex_filter.py
@@ -1,15 +1,6 @@
-import re
-from exporters.filters.key_value_base_filter import KeyValueBaseFilter
+import warnings
+from .key_value_filters import KeyValueRegexFilter  # NOQA
 
 
-class KeyValueRegexFilter(KeyValueBaseFilter):
-    """
-    Filter items depending on keys and values using regular expressions
-
-        - keys (list)
-            It is a list of dicts with the following structure: {"key": "regex"}.
-            The filter will delete those items that do not contain a
-            key "key" or, if they do, that key value does not match "regex".
-    """
-    def _match_value(self, found, expected):
-        return bool(re.match(expected, found))
+warnings.warn('Module exporters.filters.key_value_regex_filter has been deprecated,'
+              ' use exporters.filters.key_values_filters instead')


### PR DESCRIPTION
So, here are a proposal for a some minor cleanups, just for fun. :)

Summmary of changes:
1. The **init** was being overriden unnecessarily (btw, highly
   recommended talk: The Art of Subclassing, by Raymond Hettinger)
2. Renamed the meets_condition method to _match_value, because
   I think that's more descriptive and doesn't make it a "private"
   method (not part of the official interface, can be renamed later).
   Also added a docstring (important for methods without
   implementation, IMO).
3. Moved all key-value filters to the same module, keeping shims for backward compatibility.
4. Applied my own nitpicking on previous PR. :)

Obs: it's easier to review the separate commits (first for most changes, second for the move)
