### PR TITLE
fs-reader: skipping files fix

### DIFF
--- a/exporters/readers/fs_reader.py
+++ b/exporters/readers/fs_reader.py
@@ -72,7 +72,7 @@ class FSReader(BaseReader):
         if not self.files:
             self.logger.warning('Files not found for reading')
 
-        for fpath in self.files:
+        for fpath in sorted(self.files):
             with gzip.open(fpath) as f:
                 for line in f:
                     self.last_line += 1


### PR DESCRIPTION
Instead of this:

```
In [40]: files = [1, 2, 3, 4, 5]

In [41]: for f in files:
   ....:     print 'file {}, files {}'.format(f, files)
   ....:     files.remove(f)
   ....:     
file 1, files [1, 2, 3, 4, 5]
file 3, files [2, 3, 4, 5]
file 5, files [2, 4, 5]
```

It should be:

```
In [42]: files = [1, 2, 3, 4, 5]

In [43]: for f in files[:]:
    print 'file {}, files {}'.format(f, files)
    files.remove(f)
   ....:     
file 1, files [1, 2, 3, 4, 5]
file 2, files [2, 3, 4, 5]
file 3, files [3, 4, 5]
file 4, files [4, 5]
file 5, files [5]
```
