### PR TITLE
Implemented basic Hubstorage writer

### DIFF
--- a/exporters/writers/hubstorage_writer.py
+++ b/exporters/writers/hubstorage_writer.py
@@ -1,0 +1,63 @@
+import six
+from copy import copy
+from exporters.writers.base_writer import BaseWriter
+
+
+class HubstorageWriter(BaseWriter):
+    """
+    This writer sends items into Scrapinghub Hubstorage collection.
+
+        - apikey (str)
+            API key with access to the project where the items are being generated.
+
+        - project_id (str)
+            Id of the project.
+
+        - collection_name (str)
+            Name of the collection of items.
+
+        - key_field (str)
+            Record field which should be used as Hubstorage item key
+    """
+
+    # List of options to set up the writer
+    supported_options = {
+        "project_id": {
+            'type': six.string_types,
+            'help': 'Id of the project'
+        },
+        "collection_name": {
+            'type': six.string_types,
+            'help': 'Name of the collection of items'
+        },
+        'key_field': {
+            'type': six.string_types,
+            'help': 'Record field which should be used as Hubstorage item key'
+        },
+        'apikey': {'type': six.string_types, 'help': 'Hubstorage API key'}
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(HubstorageWriter, self).__init__(*args, **kwargs)
+        self.project_id = self.read_option('project_id')
+        self.collection_name = self.read_option('collection_name')
+        self.key_field = self.read_option('key_field')
+        self.collection = self._get_collection()
+        self.logger.info('Will write items into project {}, '
+                         ' collection {}'.format(self.project_id, self.collection_name))
+
+    def write_batch(self, batch):
+        super(HubstorageWriter, self).write_batch(batch)
+
+        hs_items = []
+        for item in batch:
+            hs_item = copy(item)  # shallow copy should be enough
+            hs_item['_key'] = item[self.key_field]
+            hs_items.append(hs_item)
+        self.collection.set(hs_items)
+
+    def _get_collection(self):
+        import hubstorage
+        client = hubstorage.HubstorageClient(self.read_option('apikey'))
+        project = client.get_project(self.project_id)
+        return project.collections.new_store(self.collection_name)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,5 +7,6 @@ flake8==2.5.4
 pytest-cov==2.2.1
 vcrpy==1.7.4
 fuzzywuzzy==0.8.0
+responses==0.5.1
 
 -r ../lazy_requirements.txt

--- a/tests/test_writers_hubstorage.py
+++ b/tests/test_writers_hubstorage.py
@@ -1,0 +1,46 @@
+import json
+import responses
+import unittest
+from copy import deepcopy
+
+from exporters.export_formatter.json_export_formatter import JsonExportFormatter
+from exporters.records.base_record import BaseRecord
+from exporters.writers.hubstorage_writer import HubstorageWriter
+
+from .utils import meta
+
+
+class HubstorageWriterTest(unittest.TestCase):
+    def test_should_push_items_to_hubstorage(self):
+        # given:
+        batch = [
+            BaseRecord({'name': 'item1', 'country_code': 'es'}),
+            BaseRecord({'name': 'item2', 'country_code': 'uk'}),
+            BaseRecord({'name': 'item3', 'something': 'else'}),
+        ]
+
+        options = {
+            "project_id": "10804",
+            "collection_name": "test_collection",
+            "key_field": "name",
+            'apikey': 'fakeapikey'
+        }
+
+        # when:
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as r:
+            r.add(responses.POST,
+                  "http://storage.scrapinghub.com/collections/10804/s/test_collection",
+                  body='{}')
+            writer = HubstorageWriter({"options": options}, meta(),
+                                      export_formatter=JsonExportFormatter(dict()))
+            writer.write_batch(batch)
+            written = [json.loads(l) for l in r.calls[0].request.body.split('\n')]
+
+        # then:
+        self.assertEqual(3, writer.get_metadata('items_count'))
+        expected_items = deepcopy(batch)
+        for item in expected_items:
+            item['_key'] = item['name']
+        self.assertEqual(written, expected_items)
+
+        writer.close()


### PR DESCRIPTION
I've used `collection_url` for options as `HubstorageReduceWriter` does but I'm not sure if we need to use those, e.g. `HubstorageReader` uses `project_id` and `collection_name`
