### PR TITLE
Fix key value regex filter support for nonstring values

### DIFF
--- a/exporters/filters/key_value_filters.py
+++ b/exporters/filters/key_value_filters.py
@@ -65,4 +65,6 @@ class KeyValueRegexFilter(KeyValueBaseFilter):
             key "key" or, if they do, that key value does not match "regex".
     """
     def _match_value(self, found, expected):
-        return bool(re.match(expected, found)) if found is not None else False
+        if found is None:
+            return False
+        return bool(re.match(expected, u'%s' % found))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -223,19 +223,27 @@ class KeyValueRegexFilterTest(unittest.TestCase):
         batch = list(batch)
         self.assertEqual(len(batch), 0, 'Resulting filtered batch should be empty')
 
-    def test_filter_with_none_value(self):
-        keys = [
-            {'name': 'country.state.city', 'value': 'val'}
-        ]
+    def test_filter_with_nonstring_values(self):
+        # given:
         batch = [
-            {'country': {
-                'state': {
-                    'city': None
-                }
-            }, 'value': random.randint(0, 1000)} for i in range(100)
+            {'address': {'country': None}},
+            {'address': {'country': 'US'}},
+            {'address': {'country': 3}},
+            {'address': {'country': 'BR'}},
         ]
-        filter = KeyValueRegexFilter(
-            {'options': {'keys': keys}}, meta())
-        batch = filter.filter_batch(batch)
-        batch = list(batch)
-        self.assertEqual(len(batch), 0, 'Resulting filtered batch should be empty')
+        options = {
+            'options': {
+                'keys': [{'name': 'address.country', 'value': 'US|3'}]
+            }
+        }
+        filter = KeyValueRegexFilter(options, meta())
+
+        # when:
+        result = list(filter.filter_batch(batch))
+
+        # then:
+        expected = [
+            {'address': {'country': 'US'}},
+            {'address': {'country': 3}},
+        ]
+        self.assertEqual(expected, result)


### PR DESCRIPTION
This updates the behavior for the regex filter to handle nonstring
values converting to string (actually, unicode object) before testing
regexp match, and discarding in case of None.
