### PR TITLE
When retrying, always log attempts

### DIFF
--- a/exporters/default_retries.py
+++ b/exporters/default_retries.py
@@ -24,11 +24,12 @@ def disable_retries():
 
 
 @decorator
-def log_errors(f, *args, **kw):
+def _warn_about_exceptions(f, *args, **kw):
     try:
         return f(*args, **kw)
-    except:
-        logging.warning("Failed: %s" % f.__name__)
+    except Exception as e:
+        logging.warning("Failed: {} (message was: {})".format(
+            f.__name__, str(e)))
         raise
 
 
@@ -39,7 +40,7 @@ def initialized_retry(*dargs, **dkw):
                 rargs, rkw = _retry_init(dargs, dkw)
             else:
                 rargs, rkw = dargs, dkw
-            return Retrying(*rargs, **rkw).call(log_errors(f), *args, **kw)
+            return Retrying(*rargs, **rkw).call(_warn_about_exceptions(f), *args, **kw)
 
         return wrapped_f
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,3 +10,4 @@ fuzzywuzzy==0.8.0
 responses==0.5.1
 
 -r ../lazy_requirements.txt
+testfixtures==4.9.1

--- a/tests/test_default_retries.py
+++ b/tests/test_default_retries.py
@@ -1,0 +1,20 @@
+import unittest
+from testfixtures import LogCapture
+from exporters.default_retries import initialized_retry
+
+
+class InitializeRetryTest(unittest.TestCase):
+
+    def test_check_if_exceptions_are_being_warned(self):
+        @initialized_retry(stop_max_attempt_number=3)
+        def buggy():
+            raise ValueError("oops")
+
+        with LogCapture() as l:
+            with self.assertRaisesRegexp(ValueError, "oops"):
+                buggy()
+        l.check(
+            ('root', 'WARNING', 'Failed: buggy (message was: oops)'),
+            ('root', 'WARNING', 'Failed: buggy (message was: oops)'),
+            ('root', 'WARNING', 'Failed: buggy (message was: oops)'),
+        )


### PR DESCRIPTION
Unfortunately, the retrying library does not support this behavior, so
we can't yet do this in a better way, showing the number of attempts and
all. There is a PR for it that's pending review:
https://github.com/rholder/retrying/pull/40
I propose we use the following workaround for now, so that we'll at
least know when something was retried.
