### PR TITLE
WIP - GStorage bypass

### DIFF
--- a/exporters/bypasses/__init__.py
+++ b/exporters/bypasses/__init__.py
@@ -1,5 +1,6 @@
 from exporters.bypasses.s3_to_azure_blob_bypass import S3AzureBlobBypass
 from exporters.bypasses.s3_to_azure_file_bypass import S3AzureFileBypass
+from exporters.bypasses.s3_to_gstorage_bypass import S3GStorageBypass
 from exporters.bypasses.s3_to_s3_bypass import S3Bypass
 
-default_bypass_classes = [S3Bypass, S3AzureBlobBypass, S3AzureFileBypass]
+default_bypass_classes = [S3Bypass, S3AzureBlobBypass, S3AzureFileBypass, S3GStorageBypass]

--- a/exporters/bypasses/s3_bypass_state.py
+++ b/exporters/bypasses/s3_bypass_state.py
@@ -9,6 +9,8 @@ class S3BypassState(object):
         module_loader = ModuleLoader()
         self.state = module_loader.load_persistence(config.persistence_options, metadata)
         self.state_position = self.state.get_last_position()
+        self.aws_key = aws_key
+        self.aws_secret = aws_secret
         if not self.state_position:
             self.pending = S3BucketKeysFetcher(
                 self.config.reader_options['options'], aws_key, aws_secret).pending_keys()

--- a/exporters/bypasses/s3_to_gstorage_bypass.py
+++ b/exporters/bypasses/s3_to_gstorage_bypass.py
@@ -1,0 +1,77 @@
+import datetime
+from exporters.export_managers.base_bypass import RequisitesNotMet
+from .base_s3_bypass import BaseS3Bypass
+from googleapiclient import discovery
+from oauth2client.service_account import ServiceAccountCredentials
+
+
+S3_URL_EXPIRES_IN = 1800  # half an hour should be enough
+
+
+class S3GStorageBypass(BaseS3Bypass):
+    """
+    Bypass executed by default when data source is an S3 bucket and data destination
+    is a Google Storage bucket.
+    It should be transparent to user. Conditions are:
+
+        - S3Reader and GStorageWriter are used on configuration.
+        - No filter modules are set up.
+        - No transform module is set up.
+        - No grouper module is set up.
+        - GStorageWriter has not a items_limit set in configuration.
+        - GStorageWriter has default items_per_buffer_write and size_per_buffer_write per default.
+        - GStorageWriter filebase is the root of target bucket
+    """
+
+    def __init__(self, config, metadata):
+        super(S3GStorageBypass, self).__init__(config, metadata)
+
+        credentials = self.read_option('writer', 'credentials')
+        self.project_id = credentials['project_id']
+        self.gstorage_bucket = self.read_option('writer', 'bucket')
+        gcredentials = ServiceAccountCredentials.from_json_keyfile_dict(credentials)
+        self.transfer_client = discovery.build('storagetransfer', 'v1', credentials=gcredentials)
+
+    @classmethod
+    def meets_conditions(cls, config):
+        if not config.writer_options['name'].endswith('.GStorageWriter'):
+            raise RequisitesNotMet
+        filebase = config.writer_options['options']['filebase']
+        if filebase not in ('', '/'):
+            raise RequisitesNotMet
+        super(S3GStorageBypass, cls).meets_conditions(config)
+
+    def _copy_keys(self, source_bucket, keys):
+        today = datetime.date.today()
+        today_obj = {
+            'day': today.day,
+            'month': today.month,
+            'year': today.year
+        }
+        transfer_job = {
+            'description': "Exporters bypass job",
+            'status': 'ENABLED',
+            'projectId': self.project_id,
+            'schedule': {
+                # If scheduleEndDate is the same as scheduleStartDate, the
+                # transfer will be executed only once
+                'scheduleStartDate': today_obj,
+                'scheduleEndDate': today_obj,
+            },
+            'transferSpec': {
+                'objectConditions': {
+                    'includePrefixes': [keys]
+                },
+                'awsS3DataSource': {
+                    'bucketName': source_bucket.name,
+                    'awsAccessKey': {
+                        'accessKeyId': self.bypass_state.aws_key,
+                        'secretAccessKey': self.bypass_state.aws_secret,
+                    }
+                },
+                'gcsDataSink': {
+                    'bucketName': self.gstorage_bucket
+                }
+            }
+        }
+        self.transfer_client.transferJobs().create(body=transfer_job).execute()


### PR DESCRIPTION
Opening pull request to obtain feedback. At the moment this bypass is very limited but I works. I have come up with a huge list of problems that it has:
- Waiting until the transfer is completed: There doesn't seem to be a way of doing it aside from pooling for the job status. At the moment the bypass doesn't wait for the transfer to finish.
- Adding the proper permissions to the destination bucket: Write permissions needs to be given to a google service account, but I couldn't what account is this anywhere. In the end I created a transfer from the UI and the permission was added automatically, after that the bypass worked.
- Change the object's prefix: Destination name must be equal to source name. We could overcome this by renaming the file after copying, but that introduces other problems, like the file not being copied in the first place because it would overwrite an already existing file.
- Selecting the correct files: the api doesn't support selecting a list of files, only a list of prefixes to include/exclude (bonus WTF: there is a limit of 20 prefixes that can be included). Ways of working around this:
  - We can only enable this bypass if only the `prefix` option is given, disable if there are patterns or `prefix_pointer`
  - Pass a list of object names in the include prefixes, and assume this names will not be prefixes to other objects that shouldn't be copied (this is what I have implemented so far)
  - Like the previous option, but check with the API that the object names are not prefixes to another object.
  - List all the files in the source bucket and come up with an algorithm that creates a set of include/exclude prefixes that matches only the files we want (this is the most complicated option)
- Clearing the transfer list: Making a transfer like this creates an entry in the transfer list, since it's single-time transfers, maybe we should  delete this entries after the job is finished?
