### PR TITLE
Use urlopen(key.generate_url()) instead of key.open()

### DIFF
--- a/exporters/bypasses/stream_bypass.py
+++ b/exporters/bypasses/stream_bypass.py
@@ -44,7 +44,7 @@ def ensure_tell_method(fileobj):
     if not hasattr(fileobj, 'tell') and not hasattr(fileobj, 'seek'):
         old_read = fileobj.read
 
-        def new_read(num):
+        def new_read(num=-1):
             buf = old_read(num)
             new_read.pos = new_read.pos + len(buf)
             return buf

--- a/tests/test_readers_s3.py
+++ b/tests/test_readers_s3.py
@@ -276,9 +276,7 @@ class S3ReaderTest(unittest.TestCase):
                           'test_list/dump_p2_US_a', 'test_list/dump_p_US_a'])
         streams = list(reader.get_read_streams())
         for stream_data, file_name in zip(streams, file_names):
-            key, name, size = stream_data
-            assert not key.closed
-            assert key.name == name
+            file_obj, name, size = stream_data
             assert name in file_names
             file_names.remove(name)
         assert file_names == set()


### PR DESCRIPTION
boto keys are very broken file-like objects
see: https://github.com/boto/boto/issues/3311
