### PR TITLE
Fail early when given an invalid JQ expression

### DIFF
--- a/tests/test_transforms_jq.py
+++ b/tests/test_transforms_jq.py
@@ -36,3 +36,7 @@ class JqTransformTest(unittest.TestCase):
             transform = JQTransform({'options': {'jq_filter': jq_filter}})
             expected = [{'country_code': country}]
             self.assertEqual(expected, list(transform.transform_batch(self.batch)))
+
+    def test_invalid_jq_expression(self):
+        with self.assertRaisesRegexp(ValueError, "jq: 1 compile error"):
+            JQTransform({'options': {'jq_filter': 'blah'}})


### PR DESCRIPTION
This will prevent the pipeline to start if a given config is fed with
an invalid JQ expression.
