### PR TITLE
fs_reader: speed up json lines reading

### DIFF
--- a/exporters/readers/fs_reader.py
+++ b/exporters/readers/fs_reader.py
@@ -2,6 +2,8 @@ import gzip
 import json
 import os
 import re
+from io import BufferedReader
+
 from exporters.readers.base_reader import BaseReader
 from exporters.records.base_record import BaseRecord
 from exporters.exceptions import ConfigurationError
@@ -74,11 +76,12 @@ class FSReader(BaseReader):
 
         for fpath in sorted(self.files):
             with gzip.open(fpath) as f:
-                for line in f:
-                    self.last_line += 1
-                    line = line.replace("\n", '')
-                    item = BaseRecord(json.loads(line))
-                    yield item
+                with BufferedReader(f) as bf:
+                    for line in bf:
+                        self.last_line += 1
+                        line = line.replace("\n", '')
+                        item = BaseRecord(json.loads(line))
+                        yield item
 
             self.read_files.append(fpath)
             self.files.remove(fpath)


### PR DESCRIPTION
GzipFile does buffer-related stuff, such as `GzipFile.readline` in pure Python and does it quite slowly, unlike `io.BufferedReader` which does it in C.

Check out 
- http://spyced.blogspot.com.by/2006/12/wow-gzip-module-kinda-sucks.html
- https://bugs.python.org/issue7471 states that the patch should be applied to py2.7, but it does not, at least for me
