### PR TITLE
Set valid count to false in stream bypass.

### DIFF
--- a/exporters/bypasses/stream_bypass.py
+++ b/exporters/bypasses/stream_bypass.py
@@ -119,6 +119,8 @@ class StreamBypass(BaseBypass):
         return True
 
     def execute(self):
+        # We can't count items on streamed bypasses
+        self.valid_total_count = False
         self.bypass_state = StreamBypassState(self.config, self.metadata)
         module_loader = ModuleLoader()
         reader = module_loader.load_reader(self.config.reader_options, self.metadata)


### PR DESCRIPTION
0 items are being reported in completion mails. When streaming a bypass, we can't count how much items are there, so that info should not be added to notifications.
