### PR TITLE
Add BasicExporter as top-level import (closes #289)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ The export can be run using exporters as a library:
 
 .. code-block:: python
 
-    from exporters.export_managers.basic_exporter import BasicExporter
+    from exporters import BasicExporter
 
     exporter = BasicExporter.from_file_configuration('config.json')
     exporter.export()

--- a/exporters/__init__.py
+++ b/exporters/__init__.py
@@ -1,1 +1,4 @@
 __version__ = '0.4.12'
+
+
+from exporters.export_managers import BasicExporter  # NOQA

--- a/exporters/export_managers/__init__.py
+++ b/exporters/export_managers/__init__.py
@@ -1,3 +1,5 @@
 MODULES = ['reader', 'filter_before', 'filter_after',
            'transform', 'writer', 'persistence',
            'grouper', 'notifiers']
+
+from .basic_exporter import BasicExporter  # NOQA

--- a/exporters/export_managers/basic_exporter.py
+++ b/exporters/export_managers/basic_exporter.py
@@ -1,8 +1,8 @@
 import yaml
 
 from exporters.bypasses import default_bypass_classes
-from exporters.export_managers.base_exporter import BaseExporter
 from exporters.persistence.persistence_config_dispatcher import PersistenceConfigDispatcher
+from .base_exporter import BaseExporter
 
 
 class BasicExporter(BaseExporter):


### PR DESCRIPTION
BasicExporter is one of the main entry points of exporters, so we should add it to the top-level to make it easy for people to use.

Does this look good?