### PR TITLE
Fix S3Reader skipping every other key

### DIFF
--- a/exporters/readers/s3_reader.py
+++ b/exporters/readers/s3_reader.py
@@ -297,7 +297,7 @@ class S3Reader(BaseReader):
         """
         if last_position is None:
             self.last_position = {}
-            self.last_position['keys'] = self.keys
+            self.last_position['keys'] = list(self.keys)
             self.last_position['read_keys'] = self.read_keys
             self.last_position['current_key'] = None
             self.last_position['last_block'] = 0


### PR DESCRIPTION
Copy self.keys since it's going to be modified after

This was causing every other key in s3 to not be read, the list first
was being added to last_position by reference and then removed the read
keys from it, causing the loop to skip one key for every readed key