### PR TITLE
Remove retry from non-idempotent function

### DIFF
--- a/exporters/readers/s3_reader.py
+++ b/exporters/readers/s3_reader.py
@@ -8,7 +8,7 @@ import zlib
 from six.moves.urllib.request import urlopen
 from exporters.readers.base_reader import BaseReader
 from exporters.records.base_record import BaseRecord
-from exporters.default_retries import retry_long, retry_short
+from exporters.default_retries import retry_short
 from exporters.exceptions import ConfigurationError, InvalidDateRangeError
 import logging
 
@@ -242,7 +242,6 @@ class S3Reader(BaseReader):
             file_obj = urlopen(key.generate_url(S3_URL_EXPIRES_IN))
             yield Stream(file_obj, key_name, key.size)
 
-    @retry_long
     def read_lines_from_keys(self):
         for current_key in self.keys:
             self.current_key = current_key
@@ -257,13 +256,13 @@ class S3Reader(BaseReader):
                     for i in items:
                         if i:
                             try:
-                                object = json.loads(i)
+                                obj = json.loads(i)
                             except ValueError:
                                 # Last uncomplete line
                                 self.last_leftover = i
                                 self.last_position['last_leftover'] = self.last_leftover
                             else:
-                                item = BaseRecord(object)
+                                item = BaseRecord(obj)
                                 self.last_leftover = ''
                                 self.last_position['last_leftover'] = self.last_leftover
                                 yield item


### PR DESCRIPTION
Hey fellows,

So, this is just a first step to address #303, just to avoid having incorrect results silently.

We should be mindful where to put retries in this code, because retries are really meant for code that will (probably, but as far as the code knows, always) return the same result if it is retried.

I couldn't find a good place to put more retries in this code, at least not as it is now, because it's depending on state for a good bunch of things.
So, I don't know what could be a next step to address this (leave it without retries, refactor some place?) -- would love to hear some ideas.