### PR TITLE
log when finish simple copying due to lack of direct-copy permissions

### DIFF
--- a/exporters/bypasses/s3_to_s3_bypass.py
+++ b/exporters/bypasses/s3_to_s3_bypass.py
@@ -201,6 +201,7 @@ class S3Bypass(BaseS3Bypass):
                 md5 = self._get_md5(key, tmp_filename)
                 dest_key.set_contents_from_filename(tmp_filename, cb=progress, md5=md5)
                 self._check_copy_integrity(key, dest_bucket, dest_key_name)
+        self.logger.info('Uploaded key {}'.format(dest_key_name))
 
     @retry_long
     def _copy_s3_key(self, key):


### PR DESCRIPTION
This is to make the log more verbose, in order to see better what's
actually being uploaded.