### PR TITLE
Bugfix: this will prevent the bypass code to swallow exceptions

### DIFF
--- a/exporters/export_managers/base_exporter.py
+++ b/exporters/export_managers/base_exporter.py
@@ -122,9 +122,9 @@ class BaseExporter(object):
             if bypass_class.meets_conditions(self.config):
                 try:
                     self.bypass_exporter(bypass_class)
+                    return True
                 finally:
                     self._clean_export_job()
-                    return True
         return False
 
     def _handle_export_exception(self, exception):

--- a/tests/test_export_manager.py
+++ b/tests/test_export_manager.py
@@ -180,6 +180,24 @@ class BaseExportManagerTest(unittest.TestCase):
         self.assertTrue(Bypass.executed, "Bypass should have been called")
         self.assertTrue(exporter.metadata.bypassed_pipeline)
 
+    def test_when_failing_bypass_should_raise_error(self):
+        # given:
+        self.exporter = exporter = BaseExporter(self.build_config())
+
+        class Bypass(FakeBypass):
+            executed = False
+
+            def execute(self):
+                super(Bypass, self).execute()
+                raise RuntimeError("ooops")
+        exporter.bypass_cases = [Bypass]
+
+        # when calling export, should raise the error:
+        with self.assertRaisesRegexp(RuntimeError, "ooops"):
+            exporter.export()
+
+        exporter.writer.close()
+
     def test_when_unmet_conditions_bypass_should_not_be_called(self):
         # given:
         self.exporter = exporter = BaseExporter(self.build_config())


### PR DESCRIPTION
The `return` in the `finally` block was causing exceptions to be swallowed and thus cause some jobs to fail silently.

Moving the `return True` to the try block fixes the issue.

I haven't written a test case for the bypass code, but you can verify the problem with this:

```
def some_func():
    try:
        print('will fail')
        raise ValueError("oops")
        print('this will never print')
    finally:
        print('Executing finally block')
        return True

some_func()
```

The snippet above will have the exception swallowed.