### PR TITLE
Improving retrying message

### DIFF
--- a/exporters/default_retries.py
+++ b/exporters/default_retries.py
@@ -42,7 +42,7 @@ def _warn_about_exceptions(f, *args, **kw):
     try:
         return f(*args, **kw)
     except Exception as e:
-        logging.warning("Failed: {} (message was: {})".format(
+        logging.warning("Retrying: {} (message was: {})".format(
             f.__name__, str(e)))
         raise
 

--- a/tests/test_default_retries.py
+++ b/tests/test_default_retries.py
@@ -18,9 +18,9 @@ class InitializeRetryTest(unittest.TestCase):
             with self.assertRaisesRegexp(RuntimeError, "oops"):
                 buggy()
         l.check(
-            ('root', 'WARNING', 'Failed: buggy (message was: oops)'),
-            ('root', 'WARNING', 'Failed: buggy (message was: oops)'),
-            ('root', 'WARNING', 'Failed: buggy (message was: oops)'),
+            ('root', 'WARNING', 'Retrying: buggy (message was: oops)'),
+            ('root', 'WARNING', 'Retrying: buggy (message was: oops)'),
+            ('root', 'WARNING', 'Retrying: buggy (message was: oops)'),
         )
 
     def test_by_default_retries_are_enabled(self):


### PR DESCRIPTION
We're currently showing a warning saying "Failed" for stuff
that will be retried, it makes more sense to be more explicit
and say "Retrying" (even if it ends up not retrying because it
reached the retry limit).

Sadly we can't be more precise because retrying library doesn't offer more context yet.