### PR TITLE
Filter for duplicates based on a single field

### DIFF
--- a/exporters/filters/dupe_filter.py
+++ b/exporters/filters/dupe_filter.py
@@ -1,0 +1,29 @@
+from exporters.filters.base_filter import BaseFilter
+
+
+class DupeFilter(BaseFilter):
+    """
+    Filter items depending on a key field.
+
+        - key_field (str)
+            item's key to be used to identify dupes
+    """
+    # List of options
+    supported_options = {
+        'key_field': {'type': basestring, 'default': '_key'}
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(DupeFilter, self).__init__(*args, **kwargs)
+        self.key_field = self.read_option('key_field')
+        self.key_set = set()
+
+    def filter(self, item):
+        items_key = item[self.key_field]
+        if not items_key:  # unable to determine duplicates, won't be filtered
+            return True
+
+        if items_key not in self.key_set:
+            self.key_set.add(items_key)
+            return True
+        return False

--- a/exporters/filters/dupe_filter.py
+++ b/exporters/filters/dupe_filter.py
@@ -17,10 +17,14 @@ class DupeFilter(BaseFilter):
         super(DupeFilter, self).__init__(*args, **kwargs)
         self.key_field = self.read_option('key_field')
         self.key_set = set()
+        self.logger.info('{} initialized. Key field: "{}"'.format(
+            self.__class__.__name__, self.key_field))
 
     def filter(self, item):
-        items_key = item[self.key_field]
+        items_key = item.get(self.key_field)
         if not items_key:  # unable to determine duplicates, won't be filtered
+            self.logger.warning('Item without "key" found,'
+                                ' unable to filter it.')
             return True
 
         if items_key not in self.key_set:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -344,6 +344,8 @@ class DupeFilterTest(unittest.TestCase):
         batch = list(batch)
         self.assertEqual(3, len(batch))
         self.assertEquals(set(keys), set([item['_key'] for item in batch]))
+        self.assertEquals(set(['item1', 'item3', 'item5']),
+                          set([item['name'] for item in batch]))
 
     def test_filter_duplicates_with_custom_key(self):
         keys = ['8062219f00c79c88', '1859834d918981df', 'e2abb7b480edf910']
@@ -367,6 +369,8 @@ class DupeFilterTest(unittest.TestCase):
         self.assertEqual(3, len(batch))
         self.assertEquals(set(keys),
                           set([item['custom_key'] for item in batch]))
+        self.assertEquals(set(['item1', 'item3', 'item5']),
+                          set([item['name'] for item in batch]))
 
     def test_filter_duplicates_empty_key_dont_get_filtered(self):
         items = [

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -343,8 +343,7 @@ class DupeFilterTest(unittest.TestCase):
         batch = filter.filter_batch(batch)
         batch = list(batch)
         self.assertEqual(3, len(batch))
-        for item in batch:
-            self.assertTrue(item['_key'] in keys)
+        self.assertEquals(set(keys), set([item['_key'] for item in batch]))
 
     def test_filter_duplicates_with_custom_key(self):
         keys = ['8062219f00c79c88', '1859834d918981df', 'e2abb7b480edf910']
@@ -356,6 +355,7 @@ class DupeFilterTest(unittest.TestCase):
             {'custom_key': keys[2], 'name': 'item3', 'country_code': 'uk'},
             {'custom_key': keys[2], 'name': 'item3', 'country_code': 'uk'}
         ]
+
         batch = []
         for item in items:
             record = BaseRecord(item)
@@ -365,14 +365,30 @@ class DupeFilterTest(unittest.TestCase):
         batch = filter.filter_batch(batch)
         batch = list(batch)
         self.assertEqual(3, len(batch))
-        for item in batch:
-            self.assertTrue(item['custom_key'] in keys)
+        self.assertEquals(set(keys),
+                          set([item['custom_key'] for item in batch]))
 
     def test_filter_duplicates_empty_key_dont_get_filtered(self):
         items = [
             {'_key': '', 'name': 'item1', 'country_code': 'es'},
             {'_key': '', 'name': 'item2', 'country_code': 'us'},
             {'_key': '', 'name': 'item3', 'country_code': 'uk'}
+        ]
+        batch = []
+        for item in items:
+            record = BaseRecord(item)
+            batch.append(record)
+        filter = DupeFilter({'options': {}}, meta())
+
+        batch = filter.filter_batch(batch)
+        batch = list(batch)
+        self.assertEqual(3, len(batch))
+
+    def test_filter_duplicates_items_without_keys_dont_get_filtered(self):
+        items = [
+            {'name': 'item1', 'country_code': 'es'},
+            {'name': 'item2', 'country_code': 'us'},
+            {'name': 'item3', 'country_code': 'uk'}
         ]
         batch = []
         for item in items:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -328,11 +328,11 @@ class DupeFilterTest(unittest.TestCase):
         keys = ['8062219f00c79c88', '1859834d918981df', 'e2abb7b480edf910']
         items = [
             {'_key': keys[0], 'name': 'item1', 'country_code': 'es'},
-            {'_key': keys[0], 'name': 'item1', 'country_code': 'es'},
-            {'_key': keys[1], 'name': 'item2', 'country_code': 'us'},
-            {'_key': keys[1], 'name': 'item2', 'country_code': 'us'},
-            {'_key': keys[2], 'name': 'item3', 'country_code': 'uk'},
-            {'_key': keys[2], 'name': 'item3', 'country_code': 'uk'}
+            {'_key': keys[0], 'name': 'item2', 'country_code': 'es'},
+            {'_key': keys[1], 'name': 'item3', 'country_code': 'us'},
+            {'_key': keys[1], 'name': 'item4', 'country_code': 'us'},
+            {'_key': keys[2], 'name': 'item5', 'country_code': 'uk'},
+            {'_key': keys[2], 'name': 'item6', 'country_code': 'uk'}
         ]
         batch = []
         for item in items:
@@ -349,11 +349,11 @@ class DupeFilterTest(unittest.TestCase):
         keys = ['8062219f00c79c88', '1859834d918981df', 'e2abb7b480edf910']
         items = [
             {'custom_key': keys[0], 'name': 'item1', 'country_code': 'es'},
-            {'custom_key': keys[0], 'name': 'item1', 'country_code': 'es'},
-            {'custom_key': keys[1], 'name': 'item2', 'country_code': 'us'},
-            {'custom_key': keys[1], 'name': 'item2', 'country_code': 'us'},
-            {'custom_key': keys[2], 'name': 'item3', 'country_code': 'uk'},
-            {'custom_key': keys[2], 'name': 'item3', 'country_code': 'uk'}
+            {'custom_key': keys[0], 'name': 'item2', 'country_code': 'es'},
+            {'custom_key': keys[1], 'name': 'item3', 'country_code': 'us'},
+            {'custom_key': keys[1], 'name': 'item4', 'country_code': 'us'},
+            {'custom_key': keys[2], 'name': 'item5', 'country_code': 'uk'},
+            {'custom_key': keys[2], 'name': 'item6', 'country_code': 'uk'}
         ]
 
         batch = []


### PR DESCRIPTION
When reading from a source that contains duplicates, currently there's no way to remove duplicates, this PR add a new filtering based on a single item's field. Some considerations about the filter are
- No multiple fields key are supported, if needed a transformation + filter_after could be used
- Field with an empty or None key won't get filtered because it can not be determined deterministically if two items are duplicates based on that field's value.
