### PR TITLE
current code for saving s3 key metadata for multipart uploads doesn't work

### DIFF
--- a/lazy_requirements.txt
+++ b/lazy_requirements.txt
@@ -16,6 +16,7 @@ wsgiref==0.1.2
 boltons==15.1.0
 
 PyDrive==1.2.1
+oauth2client==3.0.0
 
 gcloud==0.9.0
 protobuf==3.0.0b2

--- a/lazy_requirements.txt
+++ b/lazy_requirements.txt
@@ -15,7 +15,7 @@ wsgiref==0.1.2
 
 boltons==15.1.0
 
-PyDrive
+PyDrive==1.2.1
 
 gcloud==0.9.0
 protobuf==3.0.0b2


### PR DESCRIPTION
current code for saving s3 key metadata for multipart uploads doesn't work. Fixed using the correct way, according to boto documentation

http://boto.readthedocs.io/en/latest/ref/s3.html#boto.s3.bucket.Bucket.initiate_multipart_upload