### PR TITLE
json list files must be ended in new line in order to allow fast

### DIFF
--- a/exporters/export_formatter/json_export_formatter.py
+++ b/exporters/export_formatter/json_export_formatter.py
@@ -45,5 +45,5 @@ class JsonExportFormatter(BaseExportFormatter):
 
     def format_footer(self):
         if self.jsonlines:
-            return ''
+            return '\n'
         return '\n]'


### PR DESCRIPTION
concatenation of files (either compressed or not)